### PR TITLE
adds checks for brand word file

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ const { modifyHtml } = require('./modify-html');
 
 module.exports = {
   onPostBuild: async ({ constants: { PUBLISH_DIR }, inputs, utils }) => {
+    const wordListFile = `${PUBLISH_DIR}${inputs.pathToWordList}`;
+    if (!fs.existsSync(wordListFile)) {
+      utils.build.failBuild('No file at provided file path ☹️.');
+    }
     let brandWords = JSON.parse(
       fs.readFileSync(`${PUBLISH_DIR}${inputs.pathToWordList}`)
     );


### PR DESCRIPTION
resolving #1 by adding a check that a file exists at the provided `wordList`. if it doesn't the build will fail with an error stating the file doesn't exist.